### PR TITLE
Minor fixes to make oidcng compatible with OpenJDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,12 @@
             <version>5.4.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- API, java.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Added support for building oidcng with OpenJDK 11 and fixed issue #10 

Tested locally and still works with OpenJDK 8 and OpenJDK 11