### PR TITLE
No stacktrace for unknown clients

### DIFF
--- a/src/main/java/oidc/web/ErrorController.java
+++ b/src/main/java/oidc/web/ErrorController.java
@@ -52,7 +52,8 @@ public class ErrorController implements org.springframework.boot.web.servlet.err
             UnauthorizedException.class,
             CodeVerifierMissingException.class,
             UnsupportedPromptValueException.class,
-            TokenAlreadyUsedException.class
+            TokenAlreadyUsedException.class,
+            UnknownClientException.class
     );
 
     public ErrorController() {


### PR DESCRIPTION
When the exception UnknownClientException is raised, a stack trace follows. This can could lead to fast growing log files. 