### PR TITLE
Ensure URIs passed in the login_hint are absolute

### DIFF
--- a/oidc/src/main/java/oidc/saml/AuthnRequestContextConsumer.java
+++ b/oidc/src/main/java/oidc/saml/AuthnRequestContextConsumer.java
@@ -244,7 +244,11 @@ public class AuthnRequestContextConsumer implements Consumer<OpenSaml5Authentica
 
     private boolean isValidURI(String uri) {
         try {
-            new URI(uri);
+            URI parsed = new URI(uri);
+            if (parsed.isAbsolute() === false) {
+                // As per paragraph 1.3.2 of the SAML 2.0 core specifications
+                throw new URISyntaxException("URI provided is not an absolute URI as required by SAML 2.0 specifications.");
+            }
             return true;
         } catch (URISyntaxException e) {
             return false;


### PR DESCRIPTION
This will partially solve #271

It still allows for i.e. mailto:scoobydoo@whereareyou.org to be passed on in the login_hint.
Could additionally consider to test the scheme for one of `http`, `https`, `urn`

```
Unless otherwise indicated in this specification, all URI reference values used within SAML-defined
elements or attributes MUST consist of at least one non-whitespace character, and are REQUIRED to be
absolute [RFC 2396].
```