### PR TITLE
Handle IPv6 case

### DIFF
--- a/oidc/src/main/java/oidc/model/ProvidedRedirectURI.java
+++ b/oidc/src/main/java/oidc/model/ProvidedRedirectURI.java
@@ -37,7 +37,7 @@ public class ProvidedRedirectURI {
 
     private boolean literalCheckRequired() {
         String host = me.getHost();
-        return !"127.0.0.1".equals(host) && !"localhost".equals(host);
+        return !"127.0.0.1".equals(host) && !"localhost".equals(host) && !"[::1]".equals(host);
     }
 
     @Override


### PR DESCRIPTION
From the specifications paragraph 3.1.2.1:

"[..] Also, if the Client is a native application, it MAY use the http scheme with localhost or the IP loopback literals 127.0.0.1 or [::1] as the hostname."