### PR TITLE
Update Tink library

### DIFF
--- a/oidc/pom.xml
+++ b/oidc/pom.xml
@@ -250,12 +250,6 @@
             <artifactId>xmlsec</artifactId>
             <version>${xmlsec.version}</version>
         </dependency>
-        <!--    Fix for CVE-2021-22569    -->
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>${protobuf-java.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.jasypt</groupId>
             <artifactId>jasypt</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,13 +37,12 @@
         <mongock-bom.version>4.3.8</mongock-bom.version>
         <oauth2-oidc-sdk.version>11.30.1</oauth2-oidc-sdk.version>
         <opensaml-saml.version>5.1.6</opensaml-saml.version>
-        <protobuf-java.version>4.33.1</protobuf-java.version>
         <rest-assured.version>5.2.0</rest-assured.version>
         <require-maven.version>3.8.4</require-maven.version>
         <spring-session-data-mongodb.version>3.4.1</spring-session-data-mongodb.version>
         <spring-session-bom.version>2021.2.3</spring-session-bom.version>
         <threshold-logger.version>2.0.1</threshold-logger.version>
-        <tink.version>1.6.0</tink.version>
+        <tink.version>1.20.0</tink.version>
         <wagon-webdav-jackrabbit.version>3.5.3</wagon-webdav-jackrabbit.version>
         <wiremock-standalone.version>3.6.0</wiremock-standalone.version>
         <xmlsec.version>4.0.4</xmlsec.version>


### PR DESCRIPTION
For solving the following warning during boot. I have update the old tink library to it newest available version.

The warning:

```
As of 2022/09/29 (release 21.7) makeExtensionsImmutable should not be called from protobuf gencode. If you are seeing this message, your gencode is vulnerable to a denial of service attack. You should regenerate your code using protobuf 25.6 or later. Use the latest version that meets your needs. However, if you understand the risks and wish to continue with vulnerable gencode, you can set the system property `-Dcom.google.protobuf.use_unsafe_pre22_gencode` on the command line to silence this warning. You also can set `-Dcom.google.protobuf.error_on_unsafe_pre22_gencode` to throw an error instead. See security vulnerability: https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2
```

The current version 1.6.0 is discontinued and started with a new project from the old codebase at version 1.8: https://github.com/tink-crypto/tink-java/releases. I have updated the think library to its newest version 1.20.0

I have read through the release notes and there weren't any breaking changes, only performance and security improvements.

I have tested the application locally on the 'kennisnet' dev environment and encryption still seems to work as expected.

Side note:
I also removed the  CVE-2021-22569 overwrite since the newest version uses the latest version of protobuf so the override is no longer necessary.