### PR TITLE
Do not log stacktrace if no session was found

### DIFF
--- a/oidc/src/main/java/oidc/exceptions/CookiesNotSupportedException.java
+++ b/oidc/src/main/java/oidc/exceptions/CookiesNotSupportedException.java
@@ -1,10 +1,6 @@
 package oidc.exceptions;
 
 public class CookiesNotSupportedException extends BaseException {
-    public CookiesNotSupportedException() {
-
-        super("There is no savedRequest or cookies are not supported");
-    }
 
     public CookiesNotSupportedException(String message) {
         super(message);

--- a/oidc/src/main/java/oidc/saml/AuthnRequestContextConsumer.java
+++ b/oidc/src/main/java/oidc/saml/AuthnRequestContextConsumer.java
@@ -70,13 +70,9 @@ public class AuthnRequestContextConsumer implements Consumer<OpenSaml5Authentica
         AuthnRequest authnRequest = authnRequestContext.getAuthnRequest();
         HttpServletRequest request = authnRequestContext.getRequest();
 
-        String remoteIp = request.getHeader("X-Forwarded-For");
-
-        if (remoteIp == null || remoteIp.isEmpty() || "unknown".equalsIgnoreCase(remoteIp)) {
-            remoteIp = request.getRemoteAddr();
-        } else {
-            remoteIp = remoteIp.split(",")[0].trim();
-        }
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        String remoteIp = StringUtils.hasText(xForwardedFor) && !xForwardedFor.equalsIgnoreCase("unknown")
+            ? xForwardedFor.split(",")[0].trim() : request.getRemoteAddr();
 
         HttpSession session = request.getSession(false);
         if (session == null) {

--- a/oidc/src/test/java/oidc/web/CustomErrorControllerTest.java
+++ b/oidc/src/test/java/oidc/web/CustomErrorControllerTest.java
@@ -52,7 +52,7 @@ public class CustomErrorControllerTest {
     @Test
     @SuppressWarnings("unchecked")
     public void noCookies() throws URISyntaxException {
-        ModelAndView modelAndView = (ModelAndView) doError(new CookiesNotSupportedException());
+        ModelAndView modelAndView = (ModelAndView) doError(new CookiesNotSupportedException("test"));
         assertEquals("no_session_found", modelAndView.getViewName());
     }
 


### PR DESCRIPTION
This `CookiesNotSupportedException` happens very often. Do not log the full stacktrace, but log information we can use instead